### PR TITLE
fix(workflow): correct artifact name in build-docs.yml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   INSTANCE: 'Writerside/in'
-  ARTIFACT: 'webHelpHI2-all.zip'
+  ARTIFACT: 'webHelpIN2-all.zip'
   DOCKER_VERSION: '242.21870'
 
 jobs:


### PR DESCRIPTION
Update artifact name from 'webHelpHI2-all.zip' to 'webHelpIN2-all.zip' to ensure the correct file is used in the documentation build process. This change aligns the workflow configuration with the expected artifact naming convention, preventing potential build errors.