### PR TITLE
fix(workflow): correct Algolia app name format in build-docs.yml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,7 @@ env:
   ARTIFACT: 'webHelpIN2-all.zip'
   DOCKER_VERSION: '242.21870'
   ALGOLIA_ARTIFACT: 'algolia-indexes-IN.zip'
-  ALGOLIA_APP_NAME: 'Go Advanced Admin Docs'
+  ALGOLIA_APP_NAME: 'Go-Advanced-Admin-Docs'
   ALGOLIA_INDEX_NAME: 'docs'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'IN'


### PR DESCRIPTION
Adjusted the ALGOLIA_APP_NAME in GitHub Actions workflow to use hyphens instead of spaces. This ensures proper identification and consistency in automated processes involving Algolia.