### PR TITLE
chore: update Algolia app name in build workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,7 @@ env:
   ARTIFACT: 'webHelpIN2-all.zip'
   DOCKER_VERSION: '242.21870'
   ALGOLIA_ARTIFACT: 'algolia-indexes-IN.zip'
-  ALGOLIA_APP_NAME: 'Go-Advanced-Admin-Docs'
+  ALGOLIA_APP_NAME: 'Q154LTKUGD'
   ALGOLIA_INDEX_NAME: 'docs'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'IN'


### PR DESCRIPTION
This commit updates the Algolia application name in the GitHub workflow configuration file. The change is likely intended to correct or align the application name with the current Algolia account settings, ensuring successful deployments and indexing.