### PR TITLE
refactor: rename instance profile and update references

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,10 +10,10 @@ permissions:
   pages: write
 
 env:
-  INSTANCE: 'Writerside/d'
-  ARTIFACT: 'webHelpD2-all.zip'
+  INSTANCE: 'Writerside/gaapd'
+  ARTIFACT: 'webHelpGAAPD2-all.zip'
   DOCKER_VERSION: '242.21870'
-  ALGOLIA_ARTIFACT: 'algolia-indexes-D.zip'
+  ALGOLIA_ARTIFACT: 'algolia-indexes-GAAPD.zip'
   ALGOLIA_APP_NAME: 'Q154LTKUGD'
   ALGOLIA_INDEX_NAME: 'docs'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'

--- a/Writerside/cfg/buildprofiles.xml
+++ b/Writerside/cfg/buildprofiles.xml
@@ -4,7 +4,7 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <variables></variables>
-    <build-profile instance="d">
+    <build-profile instance="gaapd">
         <variables>
             <algolia-id>Q154LTKUGD</algolia-id>
             <algolia-index>docs</algolia-index>

--- a/Writerside/gaapd.tree
+++ b/Writerside/gaapd.tree
@@ -2,8 +2,8 @@
 <!DOCTYPE instance-profile
         SYSTEM "https://resources.jetbrains.com/writerside/1.0/product-profile.dtd">
 
-<instance-profile id="d"
-                 name="docs"
+<instance-profile id="gaapd"
+                 name="Go Advanced Admin Panel Documentation"
                  start-page="Quick-Start.md">
 
     <toc-element topic="Quick-Start.md">

--- a/Writerside/topics/Quick-Start.md
+++ b/Writerside/topics/Quick-Start.md
@@ -1,4 +1,4 @@
-# Advanced Admin Panel Documentation
+# Welcome
 
 Welcome to the documentation for the Advanced Admin Panel for Go. This guide will help you integrate the admin panel into your Go applications using various web frameworks and ORMs. Whether you're just getting started or looking to customize the admin panel to fit your needs, this documentation covers everything you need.
 

--- a/Writerside/writerside.cfg
+++ b/Writerside/writerside.cfg
@@ -7,5 +7,5 @@
     <images dir="images" web-path="images"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="d.tree"/>
+    <instance src="gaapd.tree"/>
 </ihp>


### PR DESCRIPTION
Renamed the instance profile from 'd' to 'gaapd' to better reflect its purpose as the "Go Advanced Admin Panel Documentation". Updated associated file names, environment variables, and references in configuration files to maintain consistency across the project. This enhancement improves clarity and aids in future maintenance by ensuring all documentation resources are accurately labeled.