### PR TITLE
fix: correct SQL query string handling in ORM integration guide

### DIFF
--- a/Writerside/topics/Building-a-Custom-ORM-Integration.md
+++ b/Writerside/topics/Building-a-Custom-ORM-Integration.md
@@ -226,7 +226,7 @@ func (i *Integrator) buildSearchCondition(
     var conditions []string
     for _, field := range fields {
         conditions = append(
-            conditions, fmt.Sprintf("%s LIKE '%%%s%%'", field, query), 
+            conditions, fmt.Sprintf("%s LIKE '%s'", field, query), 
         )
     }
     return strings.Join(conditions, " OR ")


### PR DESCRIPTION
The SQL LIKE clause was updated to remove unnecessary wildcards around the query parameter. This change improves the accuracy and efficiency of SQL queries by ensuring that the input is matched exactly as intended, without additional pattern matching.